### PR TITLE
Fixed typo for testing 64-bit LINT

### DIFF
--- a/LgxSimple/Program.cs
+++ b/LgxSimple/Program.cs
@@ -181,7 +181,7 @@ namespace LgxSimple
             Console.WriteLine($"latest 'STATUS_WORD' = { client.GetUint32Value(TAG_STATUS_WORD, 0) }\n");
             Console.WriteLine($"latest 'PC_HEARTBEAT' = { client.GetUint8Value(TAG_PC_HEARTBEAT, 0) }\n");
             Console.WriteLine($"latest 'MOVE_HOME' = { client.GetBitValue(TAG_MOVE_HOME, -1, DataTimeout) }\n");
-            Console.WriteLine($"latest 'LINTY' = { client.GetUint8Value(TAG_LINTY, 0) }\n");
+            Console.WriteLine($"latest 'LINTY' = { client.GetUint64Value(TAG_LINTY, 0) }\n");
             Console.WriteLine($"latest 'CONTROL_WORD.2 (JOG_REV)' = { client.GetBitValue(TAG_CONTROL_WORD, 2, DataTimeout) }\n");
 
             Console.WriteLine("}}}}}}}}}}}}}}}}}}}}}\n");


### PR DESCRIPTION
Found a typo in later testing with LINT type, doesn't break the world, but can cause concern if testing and values don't match what's on PLC.